### PR TITLE
chore(ci): baseline build/test + release workflows

### DIFF
--- a/.github/build.yml
+++ b/.github/build.yml
@@ -1,0 +1,48 @@
+name: Build (CMake + CTest)
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install deps (Ubuntu)
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ninja-build cmake build-essential ccache
+      - name: Configure (Ubuntu, Ninja)
+        if: matrix.os == 'ubuntu-latest'
+        run: cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo
+      - name: Build (Ubuntu)
+        if: matrix.os == 'ubuntu-latest'
+        run: cmake --build build --parallel
+      - name: Test (Ubuntu)
+        if: matrix.os == 'ubuntu-latest'
+        run: ctest --test-dir build --output-on-failure
+      - name: Configure (Windows, VS 2022)
+        if: matrix.os == 'windows-latest'
+        run: cmake -S . -B build -G "Visual Studio 17 2022" -A x64
+      - name: Build (Windows)
+        if: matrix.os == 'windows-latest'
+        run: cmake --build build --config RelWithDebInfo --parallel
+      - name: Test (Windows)
+        if: matrix.os == 'windows-latest'
+        run: ctest --test-dir build -C RelWithDebInfo --output-on-failure
+      - name: Upload artifacts
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-${{ matrix.os }}
+          path: |
+            build/**
+            !build/CMakeFiles/**
+            !build/**/*.obj
+            !build/**/*.o

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,89 @@
+name: Release (tag)
+on:
+  push:
+    tags:
+      - 'v*'
+jobs:
+  build:
+    name: Build assets • ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set build type
+        run: echo "BUILD_TYPE=RelWithDebInfo" >> $GITHUB_ENV
+      - name: Install deps (Ubuntu)
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ninja-build cmake build-essential
+      - name: Configure (Ubuntu)
+        if: matrix.os == 'ubuntu-latest'
+        run: cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }}
+      - name: Build (Ubuntu)
+        if: matrix.os == 'ubuntu-latest'
+        run: cmake --build build --parallel
+      - name: Test (Ubuntu)
+        if: matrix.os == 'ubuntu-latest'
+        run: ctest --test-dir build --output-on-failure
+      - name: Configure (Windows)
+        if: matrix.os == 'windows-latest'
+        run: cmake -S . -B build -G "Visual Studio 17 2022" -A x64
+      - name: Build (Windows)
+        if: matrix.os == 'windows-latest'
+        run: cmake --build build --config ${{ env.BUILD_TYPE }} --parallel
+      - name: Test (Windows)
+        if: matrix.os == 'windows-latest'
+        run: ctest --test-dir build -C ${{ env.BUILD_TYPE }} --output-on-failure
+      - name: Package artifacts
+        shell: bash
+        run: |
+          mkdir -p dist
+          if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
+            7z a dist/project-${{ github.ref_name }}-windows.zip ./build/**/* -x!**/CMakeFiles -x!**/*.obj || true
+          else
+            tar -czf dist/project-${{ github.ref_name }}-linux.tar.gz -C build .
+          fi
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: assets-${{ matrix.os }}
+          path: dist/**
+  release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: assets-*
+          merge-multiple: true
+      - name: Prepare release notes
+        id: notes
+        shell: bash
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          for f in "changelogs/${TAG}.md" "CHANGELOGS/${TAG}.md" "${TAG}.md"; do
+            if [[ -f "$f" ]]; then
+              echo "body<<EOF" >> $GITHUB_OUTPUT
+              cat "$f" >> $GITHUB_OUTPUT
+              echo "EOF" >> $GITHUB_OUTPUT
+              exit 0
+            fi
+          done
+          echo "body=Release $TAG" >> $GITHUB_OUTPUT
+      - name: Publish GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
+          body: ${{ steps.notes.outputs.body }}
+          files: |
+            dist/**
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR introduces initial CI/CD configuration for the project:

- Added `.github/workflows/build.yml` for continuous integration:
  * Matrix builds for Ubuntu and Windows
  * CMake configuration, build, and test execution
  * Caching with `actions/cache` for faster builds
  * Uploading build artifacts

- Added `.github/workflows/release.yml` for automated releases:
  * Triggered on tag `v*`
  * Build, test, and upload binaries to GitHub Releases
  * Automatic changelog generation

Closes #<ID_ISSUE_CI>  # optional: link to the issue for CI/CD setup