### PR TITLE
ci(build): show ccache stats on linux build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,6 +63,12 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: ccache -s || true
 
+      - name: Show ccache stats (Ubuntu)
+        if: always() && runner.os == 'Ubuntu'
+        run: |
+          echo "=== CCACHE STATS ==="        
+          ccache --show-stats
+
       # ---------- Windows ----------
       - name: Configure (Windows)
         if: matrix.os == 'windows-latest'


### PR DESCRIPTION
Added a step to display ccache statistics (hits, misses, config) in GitHub Actions workflow for Linux runners only. This helps monitor cache efficiency without breaking Windows builds.