### PR TITLE
feat(config): replace TOML with JSON configuration, set CM0135 policy…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,10 @@ cmake-build-*/
 # Log Catalog
 logs/
 
+# Generated data
+data/grades.txt
+test_tmp_cfg_json
+
 # Version file
 include/Version.h
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ project(QuantumGradesApp VERSION 0.4.1 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_POLICY_DEFAULT_CMP0135 NEW)
 
 if (WIN32)
 	add_compile_definitions(
@@ -63,6 +64,15 @@ configure_file(
 file(GLOB SRC_FILES ${SRC_DIR}/*.cpp)
 list(FILTER SRC_FILES EXCLUDE REGEX ".*main.cpp$")
 
+# === External libraries ===
+include(FetchContent)
+FetchContent_Declare(
+	nlohmann_json
+	URL https://github.com/nlohmann/json/archive/refs/tags/v3.11.3.tar.gz
+)
+FetchContent_MakeAvailable(nlohmann_json)
+
+
 # === Application build ===
 add_executable(app ${SRC_FILES} ${SRC_DIR}/main.cpp)
 target_include_directories(app PRIVATE ${INCLUDE_DIR})
@@ -73,6 +83,13 @@ list(FILTER TEST_FILES EXCLUDE REGEX ".*test_main.cpp$")
 
 add_executable(tests ${SRC_FILES} ${TEST_FILES} ${TEST_DIR}/test_main.cpp)
 target_include_directories(tests PRIVATE ${INCLUDE_DIR} ${EXTERNAL_DIR})
+
+# Make sure, that targets sees nlohmann_json
+target_link_libraries(app PRIVATE nlohmann_json::nlohmann_json)
+if(TARGET tests)
+	target_link_libraries(tests PRIVATE nlohmann_json::nlohmann_json)
+endif()
+
 
 # === Doxygen ===
 if(BUILD_DOCS)
@@ -97,4 +114,8 @@ endif()
 add_custom_target(clean-all
 	COMMAND ${CMAKE_COMMAND} -E rm ${CMAKE_BINARY_DIR}/*
 	COMMAND "Removing all build files..."
+	COMMAND ${CMAKE_COMMAND} -E remove_directory ${CMAKE_BINARY_DIR}/data
+	COMMAND "Removing data directory..."
+	COMMAND ${CMAKE_COMMAND} -E remove_directory ${CMAKE_BINARY_DIR}/test_tmp_cfg_json
+	COMMAND "Removing test_tmp_cfg_json directory..."	
 )

--- a/config/config.json
+++ b/config/config.json
@@ -1,0 +1,5 @@
+{
+    "logging": { "level": "DEBUG", "file": "logs/app.log" },
+    "paths": { "data_dir": "data"},
+    "engine": { "threads": 8}
+}

--- a/include/Config.h
+++ b/include/Config.h
@@ -1,0 +1,43 @@
+#pragma once
+#include <string>
+#include <fstream>
+#include <nlohmann/json.hpp>
+
+
+struct Config {
+// Default values
+    std::string dataDir = "data";
+int         threads = 4;    // [1..64]
+std::string logLevel = "INFO";
+std::string logFile = "app.log";
+
+    static Config load(const std::string& path, std::string* err = nullptr) {
+        Config c{};
+        std::ifstream in (path);
+        if (!in) {
+            if(err) *err = "config file not found: " + path + " (using defaults)";
+            return c; // Return default config if file cannot be opened
+        }
+        try {
+            nlohmann::json j; in >> j;
+            
+            if (auto it = j.find("paths"); it != j.end() && it->contains("data_dir"))
+                c.dataDir = (*it)["data_dir"].get<std::string>();
+
+            if(auto it = j.find("engine"); it != j.end() && it->contains("threads"))
+                c.threads = (*it)["threads"].get<int>();
+
+            if (auto it = j.find("logging"); it != j.end()) {
+                if(it->contains("level"))
+                    c.logLevel = (*it)["level"].get<std::string>();
+                if(it->contains("file"))
+                    c.logFile = (*it)["file"].get<std::string>();
+            }
+
+        } catch (const nlohmann::json::exception& e) {
+            if (err) *err = std::string("invalid JSON: ") + e.what();
+            // Handle JSON parsing errors
+        }
+        return c;
+    }
+};

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,8 +1,12 @@
+#include <iostream>
+#include <filesystem>
 #include "Grades.h"
 #include "Version.h"
 #include "FileManager.h"
 #include "Logger.h"
-#include <iostream>
+#include "Config.h"
+
+
 
 int main() {
 	// === Header ===
@@ -14,6 +18,25 @@ int main() {
 
 	Logger::getInstance().log(LogLevel::INFO, "[APP] Application started - version " + std::string(APP_VERSION));
 	
+	// === Load configuration ===
+	std::cout << "Loading configuration...\n";
+	
+	std::string err;
+	auto cfg = Config::load("config/config.json", &err);
+	if(!err.empty()) {
+		std::cerr << "Error loading configuration: " << err << "\n";
+		return 1;	
+	}
+
+	// Make sure Log catalog exists
+	try {
+		std::filesystem::path p{cfg.logFile};
+		if(p.has_parent_path()) std::filesystem::create_directories(p.parent_path());
+	} catch (const std::exception& e) {
+		std::cerr << "Error creating log directory: " << e.what() << "\n";
+		return 1;
+	}
+
 	// === Add grades ===
 	Grades g;
 	std::cout << "Application adds notes, prints them and their statistics\n";

--- a/tests/test_config_json.cpp
+++ b/tests/test_config_json.cpp
@@ -1,0 +1,49 @@
+#include "doctest.h"
+#include <filesystem>
+#include <fstream>
+#include "Config.h"
+
+namespace fs = std::filesystem;
+
+static fs::path tmpdir() {
+    fs::path d{"test_tmp_cfg_json"};
+    fs::create_directories(d);
+    return d;
+}
+
+TEST_SUITE("Config/JSON") {
+    TEST_CASE("Load full JSON and sets fields"){
+        auto d = tmpdir();
+        auto f = d / "full.json";
+        std::ofstream out(f);
+        out << R"({
+            "logging": {"level": "DEBUG", "file": "logs/test_log.txt" },
+            "paths": { "data_dir": "dataset" },
+            "engine": { "threads": 8 }
+        })";
+        out.close();
+
+        auto cfg = Config::load(f.string());
+        CHECK(cfg.logLevel == "DEBUG");
+        CHECK(cfg.logFile == "logs/test_log.txt");
+        CHECK(cfg.dataDir == "dataset");
+        CHECK(cfg.threads == 8);
+    }
+
+    TEST_CASE("Missing keys keep defaults") {
+        auto d = tmpdir();
+        auto f = d / "missing_keys.json";
+        std::ofstream out(f);
+        out << R"({            
+            "paths": { "data_dir": "data2" }
+        })";
+        out.close();
+
+        auto cfg = Config::load(f.string());
+        CHECK(cfg.logLevel == "INFO");
+        CHECK(cfg.logFile == "app.log"); // Default value
+        CHECK(cfg.dataDir == "data2");
+        CHECK(cfg.threads == 4); // Default value
+    }
+
+}


### PR DESCRIPTION
… and updated .gitignore

- Removed TOML-based config handling
- Added nlohman/json as configuration backend
- Updated CMakeLists.txt to use FetchContent for JSON library
- Applied CMake policy CMP0135 to avoid download timestamp warnings
- Prepared structure for future logging integration (spdlog) BREAKING CHANGE: Configuration format changed from TOML to JSON