### PR TITLE
Implement DataExporter with CSV/JSON support (#67)

### DIFF
--- a/examples/demo_db_logger_config.cpp
+++ b/examples/demo_db_logger_config.cpp
@@ -1,6 +1,7 @@
 #include "Config.hpp"
 #include "utils/SpdLogger.hpp"
 #include "ingest/DataIngest.hpp"
+#include "io/DataExporter.hpp"
 #include "Version.hpp"
 
 #include <iostream>
@@ -37,13 +38,28 @@ int main() {
     // ===== 3. Ingest Data =====
     qga::ingest::DataIngest ingest(logger);
 
-    auto series = ingest.fromCsv("data/missing.csv"); // deliberately missing
+    auto series = ingest.fromCsv("tests/data/test_http.csv"); // deliberately missing
     if (!series.has_value()) {
         logger->error("Failed to ingest data from CSV");
     } else {
         logger->info("Ingested {} bars", series->size());
-    }
+    
 
-    logger->info("Demo finished.");
+        // ===== 4. Export Data =====
+        io::DataExporter csv_exporter("export_demo.csv", logger, io::ExportFormat::CSV, false);
+        csv_exporter.exportSeries(*series);
+        
+        // ===== 5. Export Subset (Range) =====
+        if(series->size() > 1) {
+            io::DataExporter csv_range_exporter("export_demo_range.csv", logger, io::ExportFormat::CSV, false);
+            csv_range_exporter.exportRange(*series, 0, 1); // export first bar
+        }
+
+        // ===== 6. Export Full Series as JSON =====
+        io::DataExporter json_exporter("export_demo.json", logger, io::ExportFormat::JSON, false);
+        json_exporter.exportSeries(*series);
+    }
+        logger->info("Demo finished.");
     return 0;
+    
 }

--- a/include/Version.hpp
+++ b/include/Version.hpp
@@ -1,3 +1,3 @@
 #pragma once
-#define APP_VERSION "v0.6.0-18-g26286ca-dirty"
-#define APP_BUILD_DATE "2025-10-02 23:53:42"
+#define APP_VERSION "v0.6.0-19-gd7e311c-dirty"
+#define APP_BUILD_DATE "2025-10-03 17:50:15"

--- a/include/io/DataExporter.hpp
+++ b/include/io/DataExporter.hpp
@@ -1,56 +1,86 @@
 /**
  * @file DataExporter.hpp
- * @brief Export module for persisting BarSeries data to disk (CSV format).
+ * @brief Export module for persisting BarSeries data to disk (CSV/JSON format).
  */
 
 #pragma once
 
 #include <string>
+#include <memory>
 #include "domain/backtest/BarSeries.hpp"
+#include "utils/ILogger.hpp"
 
 namespace qga::io {
-    
+ 
+/**
+ * @enum ExportFormat
+ * @brief Supported export formats for serialized market data.
+ */
+enum class ExportFormat {
+    CSV,   ///< Export data as plain CSV (comma-separated values).
+    JSON   ///< Export data as JSON array of objects.
+};    
+
 /**
  * @class DataExporter
- * @brief Handles exporting time-series market data to CSV.
- * This class provides an interface for exporting BarSeries data to a specified file path. 
+ * @brief Handles exporting time-series market data to disk.
+ * 
+ * Provides an interface for exporting BarSeries data to a specified file in different formats in different
+ * formats (CSV, JSON). 
  */
 class DataExporter {
 public:
-/**
- * @brief Constructor with target output path.
- * @param outputPath The file path where data will be exported.
- * @param append If true, data will be appended to the file if it exists;
- */
-explicit DataExporter(const std::string& output_path, bool append = false);
+    /**
+     * @brief Constructor with mandatory logger.
+     * @param output_path The file path where data will be exported.
+     * @param logger Logger instance (SpdLogger, MockLogger, NullLogger).
+     * @param format Export format (CSV or JSON).
+     * @param append If true, appends instead of overwriting.
+     */
+    explicit DataExporter(const std::string& output_path,
+        std::shared_ptr<utils::ILogger> logger,
+        ExportFormat format = ExportFormat::CSV,
+        bool append = false);
 
-/**
- * @brief Destructor to ensure cleanup if needed.
- */
-virtual ~DataExporter();
+    /**
+     * @brief Destructor to ensure cleanup if needed.
+     */
+    virtual ~DataExporter();
 
-/**
- * @brief Exports the given BarSeries to the configured file.
- * 
- * @param series The series quotes to export.
- * @throws std::runtime_error if file operations fail.
- */
-virtual void exportSeries(const qga::domain::backtest::BarSeries& series);
+    /**
+     * @brief Exports the given BarSeries to the configured file.
+     * 
+     * @param series The series quotes to export.
+     * @throws std::runtime_error if file operations fail.
+     */
+    virtual void exportSeries(const qga::domain::backtest::BarSeries& series);
 
-/**
- * @brief Optional: Export a subset of the series by index.
- */
-void exportRange(const qga::domain::backtest::BarSeries& series, size_t from, size_t to);
+    /**
+     * @brief Optional: Export a subset of the series by index.
+     */
+    void exportRange(const qga::domain::backtest::BarSeries& series, size_t from, size_t to);
 
+
+    /**
+     * @brief Export the entire BarSeries to the configured file.
+     * 
+     * Alias for exportSeries(), but more explicit in intent.
+     * 
+     * @param series The full BarSeries to export.
+     */
+    void exportAll(const qga::domain::backtest::BarSeries& series);
 
 private:
+    std::string output_path_;
+    ExportFormat format_;
+    bool append_;
+    std::shared_ptr<utils::ILogger> logger_;
 
-std::string output_path_;
-bool append_;
-
-void writeHeader(std::ofstream& out);
+    void writeHeader(std::ofstream& out);
+    void writeCSV(std::ofstream& out,
+        const qga::domain::backtest::BarSeries& series);
+    void writeJSON(std::ofstream& out,
+        const qga::domain::backtest::BarSeries& series);
 };
-
-
 
 } // namespace qga::io

--- a/src/io/DataExporter.cpp
+++ b/src/io/DataExporter.cpp
@@ -2,60 +2,77 @@
 #include <fstream>
 #include <stdexcept>
 #include <sstream>
+#include "nlohmann/json.hpp"
 
+using nlohmann::json;
 namespace qga::io {
 
-    qga::io::DataExporter::DataExporter(const std::string& output_path, bool append)
-        : output_path_(output_path), append_(append) {}
+    DataExporter::DataExporter(const std::string& output_path,
+        std::shared_ptr<utils::ILogger> logger,
+        ExportFormat format,
+        bool append)
+        : output_path_(output_path),
+         format_(format), 
+         append_(append),
+         logger_(std::move(logger)) {
+        if (!logger_) {
+            throw std::invalid_argument("Logger instance cannot be null");
+        }
+        if (output_path_.empty()) {
+            throw std::invalid_argument("Output path cannot be empty");
+        }
+    }
 
-    qga::io::DataExporter::~DataExporter() = default;
+    DataExporter::~DataExporter() = default;
 
-    void qga::io::DataExporter::exportSeries(const qga::domain::backtest::BarSeries& series) {
+    void DataExporter::exportSeries(const qga::domain::backtest::BarSeries& series) {
         if (series.empty()) {
+            logger_->error("DataExporter: cannot export empty BarSeries");
             throw std::invalid_argument("BarSeries is empty");
         }
 
         std::ofstream out(output_path_, append_ ? std::ios::app : std::ios::trunc);
         if (!out.is_open()) {
+            logger_->error("DataExporter: failed to open output file: {}", output_path_);
             throw std::runtime_error("Failed to open output file: " + output_path_);
         }
 
-        if (!append_){
-            writeHeader(out);
+        if (format_ == ExportFormat::CSV) {
+            if (!append_) writeHeader(out);
+            writeCSV(out, series);
+        } else {
+            writeJSON(out, series);
         }
         
-        for (const auto& quote : series.data()) {
-            out << quote.ts_ << "," 
-                << quote.open_ << "," 
-                << quote.high_ << ","
-                << quote.low_ << "," 
-                << quote.close_ << "," 
-                << quote.volume_ << "\n";
-        }
+        logger_->info("DataExporter: successfully exported {} bars to {}", series.size(), output_path_);
+                
     }
 
     void DataExporter::exportRange(const qga::domain::backtest::BarSeries& series, size_t from, size_t to) {
         if (series.empty() || from >= to || to > series.size()) {
+            logger_->error("DataExporter: invalid range export request [{}:{})", from, to);
             throw std::invalid_argument("Series empty or invalid range");
         }
 
         std::ofstream out(output_path_, append_ ? std::ios::app : std::ios::trunc);
         if (!out.is_open()) {
+            logger_->error("DataExporter: failed to open output file {}", output_path_);
             throw std::runtime_error("Failed to open output file: " + output_path_);
         }
-        if(!append_) {
-            writeHeader(out);
-        }
-        
+
+        qga::domain::backtest::BarSeries subset;
         for (size_t i = from; i < to; ++i) {
-            const auto& bar = series[i];
-            out << bar.ts_ << "," 
-            << bar.open_ << "," 
-            << bar.high_ << ","
-            << bar.low_ << "," 
-            << bar.close_ << ","
-            << bar.volume_ << "\n";
+            subset.add(series[i]);
         }
+
+        if (format_ == ExportFormat::CSV) {
+            if (!append_) writeHeader(out);
+            writeCSV(out, subset);
+        } else {
+            writeJSON(out, subset);
+        }
+
+        logger_->info("DataExporter: exported {} rows (range) to {}", subset.size(), output_path_);
     }
 
     void DataExporter::writeHeader(std::ofstream& out) {
@@ -63,5 +80,44 @@ namespace qga::io {
             out << "timestamp,open,high,low,close,volume\n";
         }
     }
+
+    void DataExporter::writeCSV(std::ofstream& out,
+        const qga::domain::backtest::BarSeries& series) {
+        for (const auto& bar : series.data()) {
+            out << bar.ts_ << "," 
+                << bar.open_ << "," 
+                << bar.high_ << ","
+                << bar.low_ << "," 
+                << bar.close_ << ","
+                << bar.volume_ << "\n";
+        }
+    }
+
+    void DataExporter::writeJSON(std::ofstream& out,
+        const qga::domain::backtest::BarSeries& series) {
+        json j = json::array();
+        for (const auto& bar : series.data()) {
+            j.push_back({
+                {"timestamp", bar.ts_},
+                {"open", bar.open_},
+                {"high", bar.high_},
+                {"low", bar.low_},
+                {"close", bar.close_},
+                {"volume", bar.volume_}
+            });
+        }
+        out << j.dump(4); // Pretty print with 4 spaces indent
+    }
+
+    void DataExporter::exportAll(const qga::domain::backtest::BarSeries& series) {
+        if (series.empty()) {
+            logger_->warn("DataExporter: tried to export empty BarSeries");
+            return;
+        }
+        exportSeries(series);  // delegujemy do istniejącej metody
+    }
+
+
+    
 
 }   // namespace export_util


### PR DESCRIPTION
This PR implements and integrates the Report Export functionality:

Added DataExporter class with CSV/JSON export methods.

Introduced enum ExportFormat { CSV, JSON } for flexible export.

Added unit tests (test_data_exporter.cpp) covering positive and negative scenarios.

Integrated logging into DataExporter (SpdLogger/MockLogger/NullLogger).

Updated example demo_db_logger_config.cpp to demonstrate ingestion and export workflow.

All unit tests passing.

Demo example runs end-to-end:
Config → Logger → Ingest → Export (CSV + JSON)

Tested fallback/warnings for invalid or empty series.
Closes: #67