### PR TITLE
ci: attach sample outputs as artifacts (#16)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,3 +90,10 @@ jobs:
           path: |
             build/**
           if-no-files-found: ignore
+
+      - name: Upload sample outputs
+        uses: actions/upload-artifact@v4
+        with:
+          name: sample-outputs-${{ matrix.os }}
+          path: examples/outputs/*
+          if-no-files-found: ignore

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,6 +75,8 @@ list(FILTER SRC_FILES EXCLUDE REGEX ".*/main\\.cpp$")
 # === External libraries === === ===
 
 include(FetchContent)
+
+# JSON
 FetchContent_Declare(
 	nlohmann_json
 	URL https://github.com/nlohmann/json/archive/refs/tags/v3.11.3.tar.gz
@@ -84,10 +86,19 @@ FetchContent_MakeAvailable(nlohmann_json)
 # === HTTP Curl Library ===
 find_package(CURL REQUIRED)
 
-# === spdlog ===
-find_package(spdlog REQUIRED)
+# === spdlog (via FetchContent, portable, with ext fmt) ===
+set(SPDLOG_FMT_EXTERNAL ON CACHE BOOL "Use external fmt library" FORCE)
+FetchContent_Declare(
+  spdlog
+  GIT_REPOSITORY https://github.com/gabime/spdlog.git
+  GIT_TAG v1.14.1  # stabilna wersja
+)
+FetchContent_MakeAvailable(spdlog)
 
-# === spdlog ===
+# === FMT ===
+find_package(fmt REQUIRED) # not needed, because spdlog uses it internally
+
+# === SQLite3 ===
 find_package(SQLite3 REQUIRED)
 
 
@@ -96,17 +107,17 @@ find_package(SQLite3 REQUIRED)
 if(BUILD_EXAMPLES)
 	add_executable(demo_db_logger_config ${SRC_FILES} ${EXAMPLES_DIR}/demo_db_logger_config.cpp)
 	target_include_directories(demo_db_logger_config PRIVATE ${INCLUDE_DIR})
-	target_link_libraries(demo_db_logger_config PRIVATE nlohmann_json::nlohmann_json CURL::libcurl spdlog::spdlog SQLite::SQLite3)
+	target_link_libraries(demo_db_logger_config PRIVATE nlohmann_json::nlohmann_json CURL::libcurl spdlog::spdlog fmt::fmt SQLite::SQLite3)
 	target_compile_definitions(demo_db_logger_config PRIVATE USE_CURL)
 
 	add_executable(examples_config ${SRC_FILES} ${EXAMPLES_DIR}/main_config_grades.cpp)
 	target_include_directories(examples_config PRIVATE ${INCLUDE_DIR})
-	target_link_libraries(examples_config PRIVATE nlohmann_json::nlohmann_json CURL::libcurl spdlog::spdlog SQLite::SQLite3)
+	target_link_libraries(examples_config PRIVATE nlohmann_json::nlohmann_json CURL::libcurl spdlog::spdlog fmt::fmt SQLite::SQLite3)
 	target_compile_definitions(examples_config PRIVATE USE_CURL)
 
 	add_executable(examples_backtest ${SRC_FILES} ${EXAMPLES_DIR}/main_backtest.cpp)
 	target_include_directories(examples_backtest PRIVATE ${INCLUDE_DIR})
-	target_link_libraries(examples_backtest PRIVATE nlohmann_json::nlohmann_json CURL::libcurl spdlog::spdlog SQLite::SQLite3)
+	target_link_libraries(examples_backtest PRIVATE nlohmann_json::nlohmann_json CURL::libcurl spdlog::spdlog fmt::fmt SQLite::SQLite3)
 	target_compile_definitions(examples_backtest PRIVATE USE_CURL)
 endif()
 
@@ -120,7 +131,7 @@ target_compile_definitions(tests PRIVATE UNIT_TEST USE_CURL)
 
 # Make sure, that targets sees nlohmann_json
 if(TARGET tests)
-	target_link_libraries(tests PRIVATE nlohmann_json::nlohmann_json CURL::libcurl spdlog::spdlog SQLite::SQLite3)
+	target_link_libraries(tests PRIVATE nlohmann_json::nlohmann_json CURL::libcurl spdlog::spdlog fmt::fmt SQLite::SQLite3)
 endif()
 
 

--- a/examples/demo_db_logger_config.cpp
+++ b/examples/demo_db_logger_config.cpp
@@ -38,28 +38,29 @@ int main() {
     // ===== 3. Ingest Data =====
     qga::ingest::DataIngest ingest(logger);
 
-    auto series = ingest.fromCsv("tests/data/test_http.csv"); // deliberately missing
+    auto series = ingest.fromCsv("data/demo.csv");
     if (!series.has_value()) {
         logger->error("Failed to ingest data from CSV");
+        return 1;
     } else {
         logger->info("Ingested {} bars", series->size());
+    }
     
 
-        // ===== 4. Export Data =====
-        io::DataExporter csv_exporter("export_demo.csv", logger, io::ExportFormat::CSV, false);
-        csv_exporter.exportSeries(*series);
-        
-        // ===== 5. Export Subset (Range) =====
-        if(series->size() > 1) {
-            io::DataExporter csv_range_exporter("export_demo_range.csv", logger, io::ExportFormat::CSV, false);
-            csv_range_exporter.exportRange(*series, 0, 1); // export first bar
-        }
+    // ===== 4. Export Data =====
+    try {
+        io::DataExporter exporter_csv("demo_out.csv", logger, io::ExportFormat::CSV, false);
+        exporter_csv.exportAll(*series);
 
-        // ===== 6. Export Full Series as JSON =====
-        io::DataExporter json_exporter("export_demo.json", logger, io::ExportFormat::JSON, false);
-        json_exporter.exportSeries(*series);
+        io::DataExporter exporter_json("demo_out.json", logger, io::ExportFormat::JSON, false);
+        exporter_json.exportAll(*series);
+
+        logger->info("Exported series to CSV and JSON");
+    } catch (const std::exception& ex) {
+        logger->error("Exporter exception: {}", ex.what());
     }
-        logger->info("Demo finished.");
+
+    logger->info("Demo finished.");
     return 0;
     
 }

--- a/include/Version.hpp
+++ b/include/Version.hpp
@@ -1,3 +1,3 @@
 #pragma once
-#define APP_VERSION "v0.6.0-19-gd7e311c-dirty"
-#define APP_BUILD_DATE "2025-10-03 17:50:15"
+#define APP_VERSION "v0.6.0-20-g0858708-dirty"
+#define APP_BUILD_DATE "2025-10-03 21:06:34"


### PR DESCRIPTION
### Changes
- Added artifacts upload step in `build.yml` (sample outputs attached to CI runs).
- Updated `demo_data_exporter.cpp` to generate output files for artifacts.
- Adjusted `CMakeLists.txt` to fetch `spdlog` via FetchContent and use system `fmt` to resolve conflicts.
Closes #16 